### PR TITLE
chore: add envfile context.

### DIFF
--- a/context/tool.gpt
+++ b/context/tool.gpt
@@ -4,6 +4,7 @@ description: This is the global context that all Clio tools should reference.
 share context: github.com/gptscript-ai/context/cli
 share context: github.com/gptscript-ai/context/workspace
 share context: github.com/gptscript-ai/context/multi-agent
+share context: github.com/gptscript-ai/context/envfile
 
 share tools: github.com/gptscript-ai/answers-from-the-internet
 


### PR DESCRIPTION
This allows the user to set env vars that can be used to configure default behaviors for CLIs. Like AWS_REGION or AWS_PROFILE if they choose.

It makes it so that an envvar can be set, gotten or removed from the gptscript.env file in the workspace.